### PR TITLE
Replace internal ALB with service discovery

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,7 +56,7 @@ class ApplicationController < ActionController::Base
   # Resolve the SRV records for the hostname in the URL
   def expand_url(url)
     uri = URI(url)
-    resolver = Resolv::DNS.new()
+    resolver = Resolv::DNS.new(:search => [ENV["_SERVICE_DISCOVERY_NAME"]])
     srv = resolver.getresource("_#{uri.scheme}._tcp.#{uri.host}", Resolv::DNS::Resource::IN::SRV)
     uri.host = srv.target.to_s
     uri.port = srv.port.to_s

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -63,7 +63,7 @@ class ApplicationController < ActionController::Base
     
     # lookup the SRV record and use if found
     begin
-      srv = resolver.getresource("_#{uri.scheme}._tcp.#{host}", Resolv::DNS::Resource::IN::SRV)
+      srv = resolver.getresource(host, Resolv::DNS::Resource::IN::SRV)
       uri.host = srv.target.to_s
       uri.port = srv.port.to_s
     rescue => e

--- a/mu.yml
+++ b/mu.yml
@@ -5,6 +5,6 @@ service:
   port: 3000
   pathPatterns:
   - /*
-  networkMode: awsvpc
   environment:
-    BACKEND_API: "http://api.internal.service:80"
+    CRYSTAL_URL: "http://ecsdemo-crystal.${_SERVICE_DISCOVERY_NAMESPACE}/crystal"
+    NODEJS_URL: "http://ecsdemo-nodejs.${_SERVICE_DISCOVERY_NAMESPACE}/"

--- a/mu.yml
+++ b/mu.yml
@@ -6,5 +6,5 @@ service:
   pathPatterns:
   - /*
   environment:
-    CRYSTAL_URL: "http://ecsdemo-crystal.${_SERVICE_DISCOVERY_NAMESPACE}/crystal"
-    NODEJS_URL: "http://ecsdemo-nodejs.${_SERVICE_DISCOVERY_NAMESPACE}/"
+    CRYSTAL_URL: "http://ecsdemo-crystal.${ServiceDiscoveryName}/crystal"
+    NODEJS_URL: "http://ecsdemo-nodejs.${ServiceDiscoveryName}/"

--- a/mu.yml
+++ b/mu.yml
@@ -6,5 +6,5 @@ service:
   pathPatterns:
   - /*
   environment:
-    CRYSTAL_URL: "http://ecsdemo-crystal.${ServiceDiscoveryName}/crystal"
-    NODEJS_URL: "http://ecsdemo-nodejs.${ServiceDiscoveryName}/"
+    CRYSTAL_URL: "http://ecsdemo-crystal/crystal"
+    NODEJS_URL: "http://ecsdemo-nodejs/"


### PR DESCRIPTION
Leverage new feature of mu 1.5.1 to support AWS Service Discovery instead of using an internal ALB