### PR TITLE
Corrects ecsTaskExecutionRole env var hook in ecs-params template.

### DIFF
--- a/ecs-params.yml.template
+++ b/ecs-params.yml.template
@@ -1,6 +1,6 @@
 version: 1
 task_definition:
-  task_execution_role: ecsTaskExecutionRole
+  task_execution_role: $ecsTaskExecutionRole
   ecs_network_mode: awsvpc
   task_size:
     mem_limit: 0.5GB


### PR DESCRIPTION
This fixes a bug in `ecs-params.yml.template` wherein `$ecsTaskExecutionRole` is not properly brought into the template with `envsubst`, resulting in a error [during `ecs-cli` deployment](https://ecsworkshop.com/frontend/frontend/#deploy-our-frontend-application).